### PR TITLE
Multithread

### DIFF
--- a/lib/wax_iiif/builder.rb
+++ b/lib/wax_iiif/builder.rb
@@ -242,7 +242,7 @@ module WaxIiif
       obj
     end
 
-    def process_image_records(image_records, thread_count: 0)
+    def process_image_records(image_records, thread_count: Parallel.processor_count)
       resources = {}
 
       # genrate the images

--- a/lib/wax_iiif/builder.rb
+++ b/lib/wax_iiif/builder.rb
@@ -61,6 +61,8 @@ module WaxIiif
     #
     # Take the loaded data and generate all the files.
     #
+    # @param [Integer] thread_count Thread count to use for processing images concurrently. Defaults to number of processors.
+    #
     # @return [Void]
     #
     def process_data(thread_count: Parallel.processor_count)

--- a/lib/wax_iiif/builder.rb
+++ b/lib/wax_iiif/builder.rb
@@ -76,7 +76,8 @@ module WaxIiif
       data.each do |key, value|
         manifest_id   = key
         image_records = value
-        resources     = process_image_records(image_records, thread_count: thread_count)
+        resources     = process_image_records(image_records,
+                                              thread_count: thread_count)
 
         # Generate the manifest
         if manifest_id.to_s.empty?
@@ -242,7 +243,8 @@ module WaxIiif
       obj
     end
 
-    def process_image_records(image_records, thread_count: Parallel.processor_count)
+    def process_image_records(image_records,
+                              thread_count: Parallel.processor_count)
       resources = {}
 
       # genrate the images

--- a/wax_iiif.gemspec
+++ b/wax_iiif.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mini_magick', '~> 4.8'
   spec.add_runtime_dependency 'progress_bar', '~> 1.3'
+  spec.add_runtime_dependency 'parallel', '~> 1.17'
 end

--- a/wax_iiif.gemspec
+++ b/wax_iiif.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.16'
 
   spec.add_runtime_dependency 'mini_magick', '~> 4.8'
-  spec.add_runtime_dependency 'progress_bar', '~> 1.3'
   spec.add_runtime_dependency 'parallel', '~> 1.17'
+  spec.add_runtime_dependency 'progress_bar', '~> 1.3'
 end


### PR DESCRIPTION
Hi,

It's nice if `WaxIiif::Builder#process_data` is executed concurrently because it's time-consuming method. So, I made `Builder#process_data` accept thread count as optional keyword argument.

Benchmark result is here:
```
                   user     system      total        real
1 threads:     0.000444   0.002231 278.078438 (309.547599)
2 threads:     0.000099   0.000684 308.209230 (183.798010)
4 threads:     0.000106   0.000790 374.792433 (151.648174)
8 threads:     0.000091   0.000757 369.216384 (123.569482)
```

The benchmark was run against [my Rake task](https://gitlab.com/KitaitiMakoto/manga-annotation/blob/de075baa6412b2af67b9a5503261d9f72b8ed87c/Rakefile) including 210 images on a machine with 4-core CPU and 16 GiB memory.

Could you consider this patch?